### PR TITLE
Make callback argument optional

### DIFF
--- a/lib/winston-udp.js
+++ b/lib/winston-udp.js
@@ -39,6 +39,7 @@ var UDP = exports.UDP = function (_options) {
     }
     this.name = 'UDP';
     this.level = options.level;
+    this.formatter = options.formatter;
 };
 
 /** @extends winston.Transport */

--- a/lib/winston-udp.js
+++ b/lib/winston-udp.js
@@ -1,3 +1,4 @@
+'use strict';
 /*
  * winston-udp.js: Transport for outputting logs to udp
  *

--- a/lib/winston-udp.js
+++ b/lib/winston-udp.js
@@ -85,6 +85,7 @@ UDP.prototype.log = function (level, msg, meta, callback) {
                     if (err) {
                         serverError = err;
                         client.emit('error', err);
+                        self.emit('error', err);
                         if(callback){
                             callback(err, false);
                         }
@@ -99,6 +100,7 @@ UDP.prototype.log = function (level, msg, meta, callback) {
             } catch(error){
                 serverError = error;
                 client.emit('error', error);
+                self.emit('error', error);
                 if(callback){
                     callback(error, false);
                 }

--- a/lib/winston-udp.js
+++ b/lib/winston-udp.js
@@ -85,17 +85,23 @@ UDP.prototype.log = function (level, msg, meta, callback) {
                     if (err) {
                         serverError = err;
                         client.emit('error', err);
-                        callback(err, false);
+                        if(callback){
+                            callback(err, false);
+                        }
                     } else {
                         self.emit('logged');
-                        callback(null, true);
+                        if(callback){
+                            callback(null, true);
+                        }
                     }
                     return;
                 });
             } catch(error){
                 serverError = error;
                 client.emit('error', error);
-                callback(error, false);
+                if(callback){
+                    callback(error, false);
+                }
                 return;
             }
         }

--- a/lib/winston-udp.js
+++ b/lib/winston-udp.js
@@ -10,6 +10,7 @@ var util = require('util'),
     winston = require('winston');
 var os = require("os");
 var serverError = false;
+var debug = require('debug')('winston-udp');
 
 var options = {
     "level": "info",
@@ -85,8 +86,10 @@ UDP.prototype.log = function (level, msg, meta, callback) {
 
         if (!serverError) {
             try {
-                client.send(message, 0, message.length, options.port, options.server, function (err) {
+                debug('Message length: %s', message.length);
+                client.send(message, 0, message.length, options.port, options.server, function (err,length) {
                     if (err) {
+                        debug('Error message length: %s',length);
                         serverError = err;
                         client.emit('error', err);
                         self.emit('error', err);

--- a/lib/winston-udp.js
+++ b/lib/winston-udp.js
@@ -25,10 +25,9 @@ if (!inWindows) {
     var client = dgram.createSocket('udp4');
 
     client.on("error", function (err) {
-        winston.error("UDP Logger Socket error: " + err);
+        var errString = util.format('UDP Logger Socket error: %s',err);
+        winston.error(errString);
         client.close();
-        client = dgram.createSocket('udp4');
-        winston.info("UDP Logger Socket restarted.");
     });
 }
 
@@ -79,12 +78,14 @@ UDP.prototype.log = function (level, msg, meta, callback) {
             msg = this.formatter (formatterOptions);
         }
         msg = msg.replace(/\n/g, "; ");
-        var message = new Buffer(msg);
+        //Max message size is 64KB (65535 bytes).
+        //Data can be 65507 max, because of 8 bytes UDP Datagram header and 20 bytes IP Packet headers
+        //data + udp_headers + ip_headers = 65507 bytes + 8 bytes + 20 bytes = 65535 bytes
+        var message = new Buffer(msg).slice(0,65507);
 
         if (!serverError) {
             try {
                 client.send(message, 0, message.length, options.port, options.server, function (err) {
-                    //client.close();
                     if (err) {
                         serverError = err;
                         client.emit('error', err);

--- a/lib/winston-udp.js
+++ b/lib/winston-udp.js
@@ -26,6 +26,9 @@ if (!inWindows) {
 
     client.on("error", function (err) {
         winston.error("UDP Logger Socket error: " + err);
+        client.close();
+        client = dgram.createSocket('udp4');
+        winston.info("UDP Logger Socket restarted.");
     });
 }
 

--- a/lib/winston-udp.js
+++ b/lib/winston-udp.js
@@ -39,7 +39,6 @@ var UDP = exports.UDP = function (_options) {
     }
     this.name = 'UDP';
     this.level = options.level;
-    this.formatter = options.formatter;
 };
 
 /** @extends winston.Transport */

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "winston-udp",
   "description": "A UDP transport for winston",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "author": "Gabriel Jürgens <gabriel@jurgens.com.ar>",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -14,12 +14,11 @@
     "winston",
     "udp"
   ],
-  "devDependencies": {
-    "winston": "",
-    "vows": ""
-  },
-  "peerDependencies": {
+  "dependencies":{
     "winston": ">=0.5.0 <=2.2.0"
+  },
+  "devDependencies": {
+    "vows": ""
   },
   "main": "./lib/winston-udp",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "udp"
   ],
   "dependencies":{
+    "debug": "2.2.0",
     "winston": ">=0.5.0 <=2.2.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "vows": ""
   },
   "peerDependencies": {
-    "winston": ">=0.5.0 <2.2.0"
+    "winston": ">=0.5.0 <=2.2.0"
   },
   "main": "./lib/winston-udp",
   "scripts": {


### PR DESCRIPTION
Callback function must be optional, because there is another way to handle errors (putting a listener on the `'error'` event).
