### PR TITLE
Enable udp on windows and skip adding semi colons when there is a custom formatter

### DIFF
--- a/lib/winston-udp.js
+++ b/lib/winston-udp.js
@@ -18,19 +18,16 @@ var options = {
     "port": "9999"
 };
 
-var inWindows = /^win.*/i.test(os.platform());
 
-//UDP is not working on Windows Environments, so, it will be disabled
-if (!inWindows) {
-    var dgram = require('dgram');
-    var client = dgram.createSocket('udp4');
+var dgram = require('dgram');
+var client = dgram.createSocket('udp4');
 
-    client.on("error", function (err) {
-        var errString = util.format('UDP Logger Socket error: %s',err);
-        winston.error(errString);
-        client.close();
-    });
-}
+client.on("error", function (err) {
+    var errString = util.format('UDP Logger Socket error: %s',err);
+    winston.error(errString);
+    client.close();
+});
+
 
 /**
  * @constructs UDP
@@ -68,56 +65,52 @@ winston.transports.UDP = UDP;
 UDP.prototype.log = function (level, msg, meta, callback) {
     var self = this;
 
-    //UDP is not working on Windows Environments, so, it will be disabled
-    if (!inWindows) {
-        if (this.formatter){
-            var formatterOptions = {};
-            formatterOptions.level = level;
-            formatterOptions.meta = meta;
-            formatterOptions.timestamp = options.timestamp;
-            formatterOptions.message = msg;
-            msg = this.formatter (formatterOptions);
-        }
-        else {
-            msg = msg.replace(/\n/g, "; ");
-        }
-        //Max message size is 64KB (65535 bytes).
-        //Data can be 65507 max, because of 8 bytes UDP Datagram header and 20 bytes IP Packet headers
-        //data + udp_headers + ip_headers = 65507 bytes + 8 bytes + 20 bytes = 65535 bytes
-        var message = new Buffer(msg).slice(0,65507);
+    if (this.formatter){
+        var formatterOptions = {};
+        formatterOptions.level = level;
+        formatterOptions.meta = meta;
+        formatterOptions.timestamp = options.timestamp;
+        formatterOptions.message = msg;
+        msg = this.formatter (formatterOptions);
+    }
+    else {
+        msg = msg.replace(/\n/g, "; ");
+    }
+    //Max message size is 64KB (65535 bytes).
+    //Data can be 65507 max, because of 8 bytes UDP Datagram header and 20 bytes IP Packet headers
+    //data + udp_headers + ip_headers = 65507 bytes + 8 bytes + 20 bytes = 65535 bytes
+    var message = new Buffer(msg).slice(0,65507);
 
-        if (!serverError) {
-            try {
-                debug('Message length: %s', message.length);
-                client.send(message, 0, message.length, options.port, options.server, function (err,length) {
-                    if (err) {
-                        debug('Error message length: %s',length);
-                        serverError = err;
-                        client.emit('error', err);
-                        self.emit('error', err);
-                        if(callback){
-                            callback(err, false);
-                        }
-                    } else {
-                        self.emit('logged');
-                        if(callback){
-                            callback(null, true);
-                        }
+    if (!serverError) {
+        try {
+            debug('Message length: %s', message.length);
+            client.send(message, 0, message.length, options.port, options.server, function (err,length) {
+                if (err) {
+                    debug('Error message length: %s',length);
+                    serverError = err;
+                    client.emit('error', err);
+                    self.emit('error', err);
+                    if(callback){
+                        callback(err, false);
                     }
-                    return;
-                });
-            } catch(error){
-                serverError = error;
-                client.emit('error', error);
-                self.emit('error', error);
-                if(callback){
-                    callback(error, false);
+                } else {
+                    self.emit('logged');
+                    if(callback){
+                        callback(null, true);
+                    }
                 }
                 return;
+            });
+        } catch(error){
+            serverError = error;
+            client.emit('error', error);
+            self.emit('error', error);
+            if(callback){
+                callback(error, false);
             }
+            return;
         }
     }
-
 };
 
 /**
@@ -126,7 +119,7 @@ UDP.prototype.log = function (level, msg, meta, callback) {
  * @member UDP
  */
 UDP.prototype.closeClient = function() {
-    if (!inWindows && client && (typeof client.close === "function")) {
+    if (client && (typeof client.close === "function")) {
         client.close();
     }
 };

--- a/lib/winston-udp.js
+++ b/lib/winston-udp.js
@@ -78,7 +78,9 @@ UDP.prototype.log = function (level, msg, meta, callback) {
             formatterOptions.message = msg;
             msg = this.formatter (formatterOptions);
         }
-        msg = msg.replace(/\n/g, "; ");
+        else {
+            msg = msg.replace(/\n/g, "; ");
+        }
         //Max message size is 64KB (65535 bytes).
         //Data can be 65507 max, because of 8 bytes UDP Datagram header and 20 bytes IP Packet headers
         //data + udp_headers + ip_headers = 65507 bytes + 8 bytes + 20 bytes = 65535 bytes


### PR DESCRIPTION
Sending UDP packets was previously disabled on Windows. I've tested enabling it on windows with node 6 and it works fine. 

I've also removed replacing newline with semicolon when there is a custom formatter. This is because we need to send our logs in a structured format without semicolons. My thought is that you probably want the transport to send the raw output if you specify a custom formatter.

I've left these two changes in one pull request since they change the same lines. Let me know if you want me to split them into two pull requests.
