### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "dependencies": {
     "debug": "^2.2.0",
-    "winston": "^2.2.0"
+    "winston": ">=0.5.0 <3.0.0"
   },
   "devDependencies": {
     "vows": ""

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "udp"
   ],
   "dependencies": {
-    "debug": "2.2.0",
-    "winston": ">=0.5.0 <=2.2.0"
+    "debug": "^2.2.0",
+    "winston": "^2.2.0"
   },
   "devDependencies": {
     "vows": ""


### PR DESCRIPTION
`winston-udp` is currently wired to use `winston <=2.2.0`. 

This updates the dependencies to allow any version less than `3.0.0`. 

## More Details

In our application our winston dependency is configured as `"winston": "^2.2.0"`.

Winston `2.3.0` has recently been released, and after a shrinkwrap, npm automatically updated winston to this version since it matches `^2.2.0`.

Unfortunately this leads to npm installing it's own version of `winston@2.2.0` inside `winston-udp/node_modules/winston` since version `2.3.0` being used by the application no longer matches the semver spec.

The result of this is that `winston.transports.UDP` is no longer defined in our main application.