### PR TITLE
fixed message length for Mac OS X

### DIFF
--- a/lib/winston-udp.js
+++ b/lib/winston-udp.js
@@ -79,10 +79,16 @@ UDP.prototype.log = function (level, msg, meta, callback) {
             msg = this.formatter (formatterOptions);
         }
         msg = msg.replace(/\n/g, "; ");
-        //Max message size is 64KB (65535 bytes).
-        //Data can be 65507 max, because of 8 bytes UDP Datagram header and 20 bytes IP Packet headers
-        //data + udp_headers + ip_headers = 65507 bytes + 8 bytes + 20 bytes = 65535 bytes
-        var message = new Buffer(msg).slice(0,65507);
+        var message;
+        if(/^[Dd]arwin/i.test(os.platform())){
+            //Max message size in Mac OS X is 9KB (9216 bytes).
+            message = new Buffer(msg).slice(0,9216);
+        }else{
+            //Max message size is 64KB (65535 bytes).
+            //Data can be 65507 max, because of 8 bytes UDP Datagram header and 20 bytes IP Packet headers
+            //data + udp_headers + ip_headers = 65507 bytes + 8 bytes + 20 bytes = 65535 bytes
+            message = new Buffer(msg).slice(0,65507);
+        }
 
         if (!serverError) {
             try {


### PR DESCRIPTION
This patch fixes `EMSGSIZE` error in Mac OS X. Because, by default max UDP datagram size in Mac OS X is 9K. 